### PR TITLE
Handle Targeting Key error from backend

### DIFF
--- a/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
@@ -21,6 +21,7 @@ import dev.openfeature.sdk.Value
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.EventsPublisher
 import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.exceptions.ErrorCode
 import dev.openfeature.sdk.exceptions.OpenFeatureError.FlagNotFoundError
 import dev.openfeature.sdk.exceptions.OpenFeatureError.InvalidContextError
 import dev.openfeature.sdk.exceptions.OpenFeatureError.ParseError
@@ -234,6 +235,14 @@ class ConfidenceFeatureProvider private constructor(
                 value = value,
                 variant = variant,
                 reason = Reason.TARGETING_MATCH.toString()
+            )
+        }
+        ResolveReason.RESOLVE_REASON_TARGETING_KEY_ERROR -> {
+            ProviderEvaluation(
+                value = defaultValue,
+                reason = Reason.ERROR.toString(),
+                errorCode = ErrorCode.INVALID_CONTEXT,
+                errorMessage = "Invalid targeting key"
             )
         }
         else -> {


### PR DESCRIPTION
Similarly to how this error is handled in the Swift Provider: https://github.com/spotify/confidence-openfeature-provider-swift/pull/24/files#diff-1bad310998a7169fc07cc21c6d84c6ff339070d2559f7c3406b2dfc9fc76dc08R205-R211

A targeting key error can happen when a custom field in the EvaluationContext is set from the backend to be the targeting key, and the format of such EvaluationContext's field is not among the allowed types for targeting key values (at the moment of writing, a targeting key field must be a String field).