### PR TITLE
fix: On context change

### DIFF
--- a/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
@@ -60,12 +60,22 @@ class ConfidenceFeatureProvider private constructor(
     }
 
     override fun initialize(initialContext: EvaluationContext?) {
-        if (initialContext == null) return
+        initialContext?.let {
+            internalInitialize(
+                initialContext,
+                initialisationStrategy
+            )
+        }
+    }
 
+    private fun internalInitialize(
+        initialContext: EvaluationContext,
+        strategy: InitialisationStrategy
+    ) {
         // refresh cache with the last stored data
         storage.read()?.let(cache::refresh)
 
-        if (initialisationStrategy == InitialisationStrategy.ActivateAndFetchAsync) {
+        if (strategy == InitialisationStrategy.ActivateAndFetchAsync) {
             eventsPublisher.publish(OpenFeatureEvents.ProviderReady)
         }
 
@@ -84,7 +94,7 @@ class ConfidenceFeatureProvider private constructor(
                     initialContext
                 )
 
-                when (initialisationStrategy) {
+                when (strategy) {
                     InitialisationStrategy.FetchAndActivate -> {
                         // refresh the cache from the stored data
                         cache.refresh(data = storedData)
@@ -108,7 +118,14 @@ class ConfidenceFeatureProvider private constructor(
         newContext: EvaluationContext
     ) {
         if (newContext != oldContext) {
-            initialize(newContext)
+            eventsPublisher.publish(OpenFeatureEvents.ProviderStale)
+
+            // on the new context
+            // we want to fetch new values and update te storage & cache
+            internalInitialize(
+                newContext,
+                InitialisationStrategy.FetchAndActivate
+            )
         }
     }
 

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
@@ -120,8 +120,8 @@ class ConfidenceFeatureProvider private constructor(
         if (newContext != oldContext) {
             eventsPublisher.publish(OpenFeatureEvents.ProviderStale)
 
-            // on the new context
-            // we want to fetch new values and update te storage & cache
+            // on the new context we want to fetch new values and update
+            // the storage & cache right away which is why we pass `InitialisationStrategy.FetchAndActivate`
             internalInitialize(
                 newContext,
                 InitialisationStrategy.FetchAndActivate


### PR DESCRIPTION
* Stale event when the context is changed
* Provider Ready event when the fetch is completed after a context change
* new values are updated in the cache after a successful fetch following a context change.