### PR TITLE
fix: do not fail network deserialization on unknown fields

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/client/ConfidenceRemoteClient.kt
+++ b/Provider/src/main/java/com/spotify/confidence/client/ConfidenceRemoteClient.kt
@@ -136,6 +136,7 @@ private fun Response.toResolveFlags(): ResolveResponse {
     val networkJson = Json {
         serializersModule = SerializersModule {
             contextual(FlagsSerializer)
+            ignoreUnknownKeys = true
         }
     }
     return ResolveResponse.Resolved(networkJson.decodeFromString(bodyString))


### PR DESCRIPTION
A new field was added to the resolve response. This makes the resolves crash due to the default behaviour of this flag.