### PR TITLE
fix: Move apply cache into disk storage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,6 @@ jobs:
       - name: Run build debug
         run: ./gradlew assembleDebug
       - name: Run Tests
-        run: ./gradlew :Provider:testDebugUnitTest --no-daemon --stacktrace
+        run: ./gradlew :Provider:testDebugUnitTest --no-daemon --stacktrace --info
       - name: Run build release
         run: ./gradlew assembleRelease

--- a/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
@@ -261,17 +261,18 @@ class ConfidenceFeatureProvider private constructor(
                 region = region,
                 dispatcher = dispatcher
             )
+            val diskStorage = storage ?: StorageFileCache.create(context)
             val flagApplierWithRetries = flagApplier ?: FlagApplierWithRetries(
                 client = configuredClient,
                 dispatcher = dispatcher,
-                context = context
+                diskStorage = diskStorage
             )
 
             return ConfidenceFeatureProvider(
                 hooks = hooks,
                 metadata = metadata,
                 cache = cache ?: InMemoryCache(),
-                storage = storage ?: StorageFileCache.create(context),
+                storage = diskStorage,
                 initialisationStrategy = initialisationStrategy,
                 client = configuredClient,
                 flagApplier = flagApplierWithRetries,

--- a/Provider/src/main/java/com/spotify/confidence/cache/DiskStorage.kt
+++ b/Provider/src/main/java/com/spotify/confidence/cache/DiskStorage.kt
@@ -1,5 +1,6 @@
 package com.spotify.confidence.cache
 
+import com.spotify.confidence.apply.ApplyInstance
 import com.spotify.confidence.client.ResolvedFlag
 import dev.openfeature.sdk.EvaluationContext
 
@@ -12,4 +13,6 @@ interface DiskStorage {
     fun read(): CacheData?
 
     fun clear()
+    fun writeApplyData(applyData: Map<String, MutableMap<String, ApplyInstance>>)
+    fun readApplyData(): MutableMap<String, MutableMap<String, ApplyInstance>>
 }

--- a/Provider/src/main/java/com/spotify/confidence/cache/StorageFileCache.kt
+++ b/Provider/src/main/java/com/spotify/confidence/cache/StorageFileCache.kt
@@ -14,10 +14,10 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import java.io.File
 
-const val FLAGS_FILE_NAME = "confidence_flags_cache.json"
-const val APPLY_FILE_NAME = "confidence_apply_cache.json"
+internal const val FLAGS_FILE_NAME = "confidence_flags_cache.json"
+internal const val APPLY_FILE_NAME = "confidence_apply_cache.json"
 
-class StorageFileCache private constructor(
+internal class StorageFileCache private constructor(
     private val flagsFile: File,
     private val applyFile: File
 ) : DiskStorage {

--- a/Provider/src/main/java/com/spotify/confidence/cache/StorageFileCache.kt
+++ b/Provider/src/main/java/com/spotify/confidence/cache/StorageFileCache.kt
@@ -1,17 +1,26 @@
 package com.spotify.confidence.cache
 
 import android.content.Context
+import com.spotify.confidence.apply.ApplyInstance
 import com.spotify.confidence.client.ResolvedFlag
+import com.spotify.confidence.client.serializers.UUIDSerializer
+import dev.openfeature.sdk.DateSerializer
 import dev.openfeature.sdk.EvaluationContext
 import dev.openfeature.sdk.Value
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import java.io.File
 
 const val FLAGS_FILE_NAME = "confidence_flags_cache.json"
+const val APPLY_FILE_NAME = "confidence_apply_cache.json"
 
-class StorageFileCache private constructor(private val file: File) : DiskStorage {
+class StorageFileCache private constructor(
+    private val flagsFile: File,
+    private val applyFile: File
+) : DiskStorage {
 
     override fun store(
         resolvedFlags: List<ResolvedFlag>,
@@ -29,30 +38,50 @@ class StorageFileCache private constructor(private val file: File) : DiskStorage
     }
 
     override fun clear() {
-        file.delete()
+        flagsFile.delete()
+    }
+
+    override fun writeApplyData(applyData: Map<String, MutableMap<String, ApplyInstance>>) {
+        applyFile.writeText(json.encodeToString(applyData))
+    }
+
+    override fun readApplyData(): MutableMap<String, MutableMap<String, ApplyInstance>> {
+        if (!applyFile.exists()) return mutableMapOf()
+        val fileText: String = applyFile.bufferedReader().use { it.readText() }
+        return if (fileText.isEmpty()) {
+            mutableMapOf()
+        } else {
+            json.decodeFromString(fileText)
+        }
     }
 
     private fun write(data: String) {
-        file.writeText(data)
+        flagsFile.writeText(data)
     }
 
     override fun read(): CacheData? {
-        if (!file.exists()) return null
-        val fileText: String = file.bufferedReader().use { it.readText() }
-        if (fileText.isEmpty()) return null
-        return Json.decodeFromString(fileText)
+        if (!flagsFile.exists()) return null
+        val fileText: String = flagsFile.bufferedReader().use { it.readText() }
+        return if (fileText.isEmpty()) {
+            null
+        } else {
+            Json.decodeFromString(fileText)
+        }
     }
 
     companion object {
         fun create(context: Context): DiskStorage {
-            return StorageFileCache(File(context.filesDir, FLAGS_FILE_NAME))
+            return StorageFileCache(
+                flagsFile = File(context.filesDir, FLAGS_FILE_NAME),
+                applyFile = File(context.filesDir, APPLY_FILE_NAME)
+            )
         }
 
         /**
          * Testing purposes only!
          */
-        fun forFile(file: File): DiskStorage {
-            return StorageFileCache(file)
+        fun forFiles(flagsFile: File, applyFile: File): DiskStorage {
+            return StorageFileCache(flagsFile, applyFile)
         }
     }
 }
@@ -79,3 +108,10 @@ data class CacheData(
     val evaluationContextHash: Int,
     val values: Map<String, ProviderCache.CacheEntry>
 )
+
+internal val json = Json {
+    serializersModule = SerializersModule {
+        contextual(UUIDSerializer)
+        contextual(DateSerializer)
+    }
+}

--- a/Provider/src/main/java/com/spotify/confidence/cache/StorageFileCache.kt
+++ b/Provider/src/main/java/com/spotify/confidence/cache/StorageFileCache.kt
@@ -11,8 +11,7 @@ import java.io.File
 
 const val FLAGS_FILE_NAME = "confidence_flags_cache.json"
 
-class StorageFileCache private constructor(context: Context) : DiskStorage {
-    private val file: File = File(context.filesDir, FLAGS_FILE_NAME)
+class StorageFileCache private constructor(private val file: File) : DiskStorage {
 
     override fun store(
         resolvedFlags: List<ResolvedFlag>,
@@ -46,7 +45,14 @@ class StorageFileCache private constructor(context: Context) : DiskStorage {
 
     companion object {
         fun create(context: Context): DiskStorage {
-            return StorageFileCache(context)
+            return StorageFileCache(File(context.filesDir, FLAGS_FILE_NAME))
+        }
+
+        /**
+         * Testing purposes only!
+         */
+        fun forFile(file: File): DiskStorage {
+            return StorageFileCache(file)
         }
     }
 }

--- a/Provider/src/test/java/com/spotify/confidence/ConfidenceFeatureProviderTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/ConfidenceFeatureProviderTests.kt
@@ -10,11 +10,11 @@
 package com.spotify.confidence
 
 import android.content.Context
-import com.spotify.confidence.apply.APPLY_FILE_NAME
 import com.spotify.confidence.apply.EventStatus
 import com.spotify.confidence.apply.FlagsAppliedMap
-import com.spotify.confidence.apply.json
+import com.spotify.confidence.cache.APPLY_FILE_NAME
 import com.spotify.confidence.cache.InMemoryCache
+import com.spotify.confidence.cache.json
 import com.spotify.confidence.cache.toCacheData
 import com.spotify.confidence.client.AppliedFlag
 import com.spotify.confidence.client.ConfidenceClient

--- a/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
@@ -59,7 +59,7 @@ class ConfidenceIntegrationTests {
             )
         )
 
-        val storage = StorageFileCache.forFile(tmpFile.newFile()).apply {
+        val storage = StorageFileCache.create(mockContext).apply {
             val flags = listOf(
                 ResolvedFlag(
                     "test-flag-1",

--- a/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
@@ -19,7 +19,9 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.File
@@ -30,6 +32,10 @@ private const val clientSecret = "ldZWlt6ywPIiPNf16WINSTh0yoHzSQEc"
 private val mockContext: Context = mock()
 
 class ConfidenceIntegrationTests {
+
+    @get:Rule
+    var tmpFile = TemporaryFolder()
+
     @Before
     fun setup() {
         whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("tmpTests").toFile())
@@ -53,7 +59,7 @@ class ConfidenceIntegrationTests {
             )
         )
 
-        StorageFileCache.create(mockContext).apply {
+        val storage = StorageFileCache.forFile(tmpFile.newFile()).apply {
             val flags = listOf(
                 ResolvedFlag(
                     "test-flag-1",
@@ -79,6 +85,7 @@ class ConfidenceIntegrationTests {
             ConfidenceFeatureProvider.create(
                 mockContext,
                 clientSecret,
+                storage = storage,
                 initialisationStrategy = InitialisationStrategy.ActivateAndFetchAsync,
                 eventsPublisher = eventsHandler
             ),


### PR DESCRIPTION
All file i/o should now be contained behind the DiskStorage interface which will improve testability.