### PR TITLE
ci: remove release step to upload aar

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -87,12 +87,3 @@ jobs:
       - name: Clean up signing secrets
         run: rm ~/.gradle/gradle.properties
 
-      - name: Upload Confidence Provider SDK AAR 🗳
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_PUBLISH }}
-        with:
-          upload_url: ${{ needs.release-please.outputs.upload_url }}
-          asset_path: Provider/build/outputs/aar/Provider-release.aar
-          asset_name: provider-sdk.aar
-          asset_content_type: application/aar


### PR DESCRIPTION
This step [failed](https://github.com/spotify/confidence-openfeature-provider-kotlin/actions/runs/6457650157/job/17529664108) during the last release. Either we remove it or fix it somehow but I'm not perfectly sure why we have it.
cc @vahidlazio do you know?