### PR TITLE
test: add forgotten mocks for apply

### DIFF
--- a/Provider/src/test/java/com/spotify/confidence/ConfidenceFeatureProviderTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/ConfidenceFeatureProviderTests.kt
@@ -128,6 +128,7 @@ internal class ConfidenceFeatureProviderTests {
             eventsPublisher = EventHandler.eventsPublisher(testDispatcher),
             dispatcher = testDispatcher
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -241,7 +242,6 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher
         )
         val cacheFile = File(mockContext.filesDir, APPLY_FILE_NAME)
-
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -380,7 +380,7 @@ internal class ConfidenceFeatureProviderTests {
 
         val evaluationContext1 = ImmutableContext("foo")
         val evaluationContext2 = ImmutableContext("bar")
-
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), eq(evaluationContext1))).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -735,6 +735,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -768,7 +769,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
-
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -888,7 +889,7 @@ internal class ConfidenceFeatureProviderTests {
                 )
             )
         )
-
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlagInvalidKey, "token1")
@@ -935,6 +936,7 @@ internal class ConfidenceFeatureProviderTests {
                 )
             )
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedNonMatchingFlags, "token1")
@@ -970,7 +972,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
-
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -1006,6 +1008,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenThrow(Error())
         confidenceFeatureProvider.initialize(ImmutableContext("user1"))
         advanceUntilIdle()
@@ -1031,6 +1034,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveResponse.NotModified)
         confidenceFeatureProvider.initialize(ImmutableContext("user1"))
         advanceUntilIdle()
@@ -1048,6 +1052,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")
@@ -1076,6 +1081,7 @@ internal class ConfidenceFeatureProviderTests {
             dispatcher = testDispatcher,
             client = mockClient
         )
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
                 ResolveFlags(resolvedFlags, "token1")

--- a/Provider/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
@@ -10,6 +10,7 @@ import com.spotify.confidence.client.ResolveFlags
 import com.spotify.confidence.client.ResolveReason
 import com.spotify.confidence.client.ResolveResponse
 import com.spotify.confidence.client.ResolvedFlag
+import com.spotify.confidence.client.Result
 import dev.openfeature.sdk.ImmutableContext
 import dev.openfeature.sdk.ImmutableStructure
 import dev.openfeature.sdk.Reason
@@ -67,6 +68,7 @@ class StorageFileCacheTests {
     @Test
     fun testOfflineScenarioLoadsStoredCache() = runTest {
         val mockClient: ConfidenceClient = mock()
+        whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventPublisher = EventHandler.eventsPublisher(testDispatcher)
         eventPublisher.publish(OpenFeatureEvents.ProviderStale)


### PR DESCRIPTION
We had [this error](https://github.com/spotify/confidence-openfeature-provider-kotlin/actions/runs/6458441725/job/17532155543#step:9:657) in one of the latest builds and since we are not really in control when the apply events are sent and retried, I believe it makes sense to always mock the `apply(x,y)` function on the client.