### PR TITLE
chore: bump kotlinx-serialization to 1.6.0

### DIFF
--- a/Provider/build.gradle.kts
+++ b/Provider/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 object Versions {
     const val openFeatureSDK = "v0.0.2"
     const val okHttp = "4.10.0"
-    const val kotlinxSerialization = "1.5.1"
+    const val kotlinxSerialization = "1.6.0"
     const val coroutines = "1.7.1"
     const val junit = "4.13.2"
     const val kotlinMockito = "4.1.0"

--- a/Provider/src/main/java/com/spotify/confidence/apply/FlagApplierWithRetries.kt
+++ b/Provider/src/main/java/com/spotify/confidence/apply/FlagApplierWithRetries.kt
@@ -126,7 +126,7 @@ class FlagApplierWithRetries(
         sendChannel: SendChannel<FlagApplierBatchProcessedInput>,
         coroutineExceptionHandler: CoroutineExceptionHandler
     ) {
-        data.entries.forEach { (token, flagsForToken) ->
+        for ((token, flagsForToken) in data.entries) {
             val appliedFlagsKeyed: List<AppliedFlag> = flagsForToken.entries
                 .filter { e ->
                     e.value.eventStatus == EventStatus.CREATED
@@ -155,7 +155,7 @@ class FlagApplierWithRetries(
         data: FlagsAppliedMap,
         eventStatus: EventStatus
     ) {
-        appliedFlag.forEach { applied ->
+        for (applied in appliedFlag) {
             data[token]?.let { map ->
                 computeIfPresent(map, applied.flag) { _, v ->
                     v.copy(eventStatus = eventStatus)
@@ -191,7 +191,7 @@ class FlagApplierWithRetries(
         data: FlagsAppliedMap
     ) = coroutineScope {
         val readData: MutableMap<String, MutableMap<String, ApplyInstance>> = diskStorage.readApplyData()
-        readData.entries.forEach { (resolveToken, eventsByFlagName) ->
+        for ((resolveToken, eventsByFlagName) in readData.entries) {
             eventsByFlagName.entries.forEach { (flagName, applyInstance) ->
                 putIfAbsent(data, resolveToken, hashMapOf())
                 data[resolveToken]?.let { map ->

--- a/Provider/src/main/java/com/spotify/confidence/client/serializers/Serializers.kt
+++ b/Provider/src/main/java/com/spotify/confidence/client/serializers/Serializers.kt
@@ -44,9 +44,9 @@ internal object StructureSerializer : KSerializer<Structure> {
 
     override fun serialize(encoder: Encoder, value: Structure) {
         encoder.encodeStructure(descriptor) {
-            value.asMap().forEach { (key, value) ->
+            for ((key, mapValue) in value.asMap()) {
                 encodeStringElement(descriptor, 0, key)
-                encodeSerializableElement(descriptor, 1, StructureValueSerializer, value)
+                encodeSerializableElement(descriptor, 1, StructureValueSerializer, mapValue)
             }
         }
     }


### PR DESCRIPTION
This bumps the kotlinx-serialization dependency and fixes some minSDK 21 failures.
Fixes #98 