### PR TITLE
fix: correctly handle apply response in event processor

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/client/ConfidenceRemoteClient.kt
+++ b/Provider/src/main/java/com/spotify/confidence/client/ConfidenceRemoteClient.kt
@@ -130,11 +130,17 @@ class ConfidenceRemoteClient : ConfidenceClient {
             sdkMetadata.sdkId,
             sdkMetadata.sdkVersion
         )
-        applyInteractor(request).runCatching {
-            return Result.Failure
+        val result = applyInteractor(request).runCatching {
+            if (isSuccessful) {
+                Result.Success
+            } else {
+                Result.Failure
+            }
+        }.getOrElse {
+            Result.Failure
         }
 
-        return Result.Success
+        return result
     }
 }
 


### PR DESCRIPTION
We never handled the response coming back from the client when doing the apply request.
This is used to decide the state of the apply event and if we try to send it again.