### PR TITLE
chore: add a default endpoint to the provider

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
@@ -252,7 +252,7 @@ class ConfidenceFeatureProvider private constructor(
         fun create(
             context: Context,
             clientSecret: String,
-            region: ConfidenceRegion = ConfidenceRegion.EUROPE,
+            region: ConfidenceRegion = ConfidenceRegion.GLOBAL,
             initialisationStrategy: InitialisationStrategy = InitialisationStrategy.FetchAndActivate,
             hooks: List<Hook<*>> = listOf(),
             client: ConfidenceClient? = null,

--- a/Provider/src/main/java/com/spotify/confidence/client/CommonTypes.kt
+++ b/Provider/src/main/java/com/spotify/confidence/client/CommonTypes.kt
@@ -1,6 +1,7 @@
 package com.spotify.confidence.client
 
 enum class ConfidenceRegion {
+    GLOBAL,
     EUROPE,
     USA
 }

--- a/Provider/src/main/java/com/spotify/confidence/client/ConfidenceRemoteClient.kt
+++ b/Provider/src/main/java/com/spotify/confidence/client/ConfidenceRemoteClient.kt
@@ -45,6 +45,7 @@ class ConfidenceRemoteClient : ConfidenceClient {
             "application/json"
         )
         baseUrl = when (region) {
+            ConfidenceRegion.GLOBAL -> "https://resolver.confidence.dev"
             ConfidenceRegion.EUROPE -> "https://resolver.eu.confidence.dev"
             ConfidenceRegion.USA -> "https://resolver.us.confidence.dev"
         }


### PR DESCRIPTION
Previously, the region would default to Europe. This PR is changing this to GLOBAL and is specifying a URL for that.