### PR TITLE
fix: Remove STALE event

### DIFF
--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/MainVm.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/MainVm.kt
@@ -15,7 +15,6 @@ import dev.openfeature.sdk.FlagEvaluationDetails
 import dev.openfeature.sdk.ImmutableContext
 import dev.openfeature.sdk.OpenFeatureAPI
 import dev.openfeature.sdk.Value
-import dev.openfeature.sdk.async.setProviderAndWait
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.UUID

--- a/Provider/build.gradle.kts
+++ b/Provider/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 object Versions {
-    const val openFeatureSDK = "0.2.2"
+    const val openFeatureSDK = "0.2.3"
     const val okHttp = "4.10.0"
     const val kotlinxSerialization = "1.6.0"
     const val coroutines = "1.7.3"

--- a/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
@@ -120,8 +120,6 @@ class ConfidenceFeatureProvider private constructor(
         newContext: EvaluationContext
     ) {
         if (newContext != oldContext) {
-            eventHandler.publish(OpenFeatureEvents.ProviderStale)
-
             // on the new context we want to fetch new values and update
             // the storage & cache right away which is why we pass `InitialisationStrategy.FetchAndActivate`
             internalInitialize(

--- a/Provider/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
@@ -15,8 +15,6 @@ import dev.openfeature.sdk.ImmutableContext
 import dev.openfeature.sdk.ImmutableStructure
 import dev.openfeature.sdk.Reason
 import dev.openfeature.sdk.Value
-import dev.openfeature.sdk.events.EventHandler
-import dev.openfeature.sdk.events.OpenFeatureEvents
 import dev.openfeature.sdk.events.awaitReadyOrError
 import junit.framework.TestCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,13 +62,12 @@ class StorageFileCacheTests {
         whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("tmpTests").toFile())
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testOfflineScenarioLoadsStoredCache() = runTest {
         val mockClient: ConfidenceClient = mock()
         whenever(mockClient.apply(any(), any())).thenReturn(Result.Success)
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val eventPublisher = EventHandler(testDispatcher)
-        eventPublisher.publish(OpenFeatureEvents.ProviderStale)
         val cache1 = InMemoryCache()
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(
             ResolveResponse.Resolved(
@@ -81,7 +78,6 @@ class StorageFileCacheTests {
             context = mockContext,
             clientSecret = "",
             client = mockClient,
-            eventHandler = eventPublisher,
             cache = cache1
         )
         provider1.initialize(ImmutableContext(targetingKey = "user1"))

--- a/Provider/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
@@ -15,9 +15,9 @@ import dev.openfeature.sdk.ImmutableContext
 import dev.openfeature.sdk.ImmutableStructure
 import dev.openfeature.sdk.Reason
 import dev.openfeature.sdk.Value
-import dev.openfeature.sdk.async.awaitReadyOrError
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.events.awaitReadyOrError
 import junit.framework.TestCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher

--- a/README.md
+++ b/README.md
@@ -57,12 +57,11 @@ Where:
 
 ### Changing context after the provider initialization 
 The evaluation context can be changed during the app session using `setEvaluationContext(...)`.
-After calling this method the new context is set for the provider and the flags will be fetched again and the cache and storage will be updated accordingly.
-The OpenFeature Events `ProviderStale` and `ProviderReady` events will be emitted accordingly.
+After calling this method the new context is set for the provider, the flags will be fetched again and the cache and storage will be updated accordingly. The event `ProviderReady` will be emitted once the new flags are ready to be consumed by the application (note that the selected initialization strategy property doesn't play a role in this case).
 
 Notes:
 - If a flag can't be resolved from cache, the provider does NOT automatically resort to calling remote: refreshing the cache from remote only happens when setting a new provider and/or evaluation context in the global OpenFeatureAPI
-- It's advised not to perform resolves while `setProvider` and `setEvaluationContext` are running: resolves might return the default value with reason `STALE` during such operations.
+- It's advised not to perform resolves while `setProvider` and `setEvaluationContext` are running: resolves might return the default value with reason `STALE` during such operations. The event `ProviderReady` can be used to guarantee correctness.
 
 ## Apply events
 This Provider automatically emits `apply` events to the Confidence backend once a flag's property is read by the application. This allows Confidence to track who was exposed to what variant and when.


### PR DESCRIPTION
The reasons behind this change:
- This is currently not working as expected, since in case of `activateAndFetchAsync` the STALE event is emitted even if it shouldn't
- According to [this WIP Proposal](https://github.com/open-feature/spec/pull/241/files), no event is expected prior to "initialize". 
- The STALE event is not meant to indicate a "not-ready cache" anyway: it's meant be used only if the system detects a change of flag evaluation data (for the same evaluation context). From the same PR mentioned above, a new events will be introduced for context reconciliation: `PROVIDER_CONTEXT_PENDING` and `PROVIDER_CONTEXT_CHANGED` 

Similar to the Swift Provider change: https://github.com/spotify/confidence-openfeature-provider-swift/pull/78