### PR TITLE
fix: use the local DateSerializer

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/ConfidenceValue.kt
+++ b/Provider/src/main/java/com/spotify/confidence/ConfidenceValue.kt
@@ -1,8 +1,8 @@
 package com.spotify.confidence
 
 import com.spotify.confidence.client.serializers.ConfidenceValueSerializer
+import com.spotify.confidence.client.serializers.DateSerializer
 import com.spotify.confidence.client.serializers.DateTimeSerializer
-import dev.openfeature.sdk.DateSerializer
 import kotlinx.serialization.Serializable
 
 @Serializable(ConfidenceValueSerializer::class)


### PR DESCRIPTION
The provider defines its own `DateSerializer` so this is what we should use.