### PR TITLE
feat: include persistent visitor id in context

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Provider/src/main/java/com/spotify/confidence/Confidence.kt
@@ -116,6 +116,8 @@ class Confidence internal constructor(
     }
 }
 
+internal const val VISITOR_ID_CONTEXT_KEY = "visitorId"
+
 object ConfidenceFactory {
     fun create(
         context: Context,
@@ -152,6 +154,8 @@ object ConfidenceFactory {
             flagResolver = flagResolver,
             diskStorage = FileDiskStorage.create(context),
             flagApplierClient = flagApplierClient
-        )
+        ).apply {
+            putContext(VISITOR_ID_CONTEXT_KEY, ConfidenceValue.String(VisitorUtil.getId(context)))
+        }
     }
 }

--- a/Provider/src/main/java/com/spotify/confidence/VisitorUtil.kt
+++ b/Provider/src/main/java/com/spotify/confidence/VisitorUtil.kt
@@ -1,0 +1,22 @@
+package com.spotify.confidence
+
+import android.content.Context
+import java.util.UUID
+
+internal const val SHARED_PREFS_NAME = "confidence-visitor"
+internal const val VISITOR_ID_SHARED_PREFS_KEY = "visitorId"
+internal const val DEFAULT_VALUE = "unable-to-read"
+
+internal object VisitorUtil {
+    fun getId(context: Context): String {
+        return with(context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)) {
+            if (contains(VISITOR_ID_SHARED_PREFS_KEY)) {
+                getString(VISITOR_ID_SHARED_PREFS_KEY, DEFAULT_VALUE) ?: DEFAULT_VALUE
+            } else {
+                val visitorId = UUID.randomUUID().toString()
+                edit().putString(VISITOR_ID_SHARED_PREFS_KEY, visitorId).apply()
+                visitorId
+            }
+        }
+    }
+}

--- a/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
@@ -1,6 +1,7 @@
 package com.spotify.confidence
 
 import android.content.Context
+import android.content.SharedPreferences
 import com.spotify.confidence.cache.FLAGS_FILE_NAME
 import com.spotify.confidence.cache.FileDiskStorage
 import com.spotify.confidence.client.ResolveReason
@@ -22,6 +23,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.File
@@ -30,6 +32,8 @@ import java.util.UUID
 
 private const val clientSecret = "21wxcxXpU6tKBRFtEFTXYiH7nDqL86Mm"
 private val mockContext: Context = mock()
+private val mockSharedPrefs: SharedPreferences = mock()
+private val mockSharedPrefsEdit: SharedPreferences.Editor = mock()
 
 class ConfidenceIntegrationTests {
 
@@ -40,6 +44,10 @@ class ConfidenceIntegrationTests {
     fun setup() {
         whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("tmpTests").toFile())
         whenever(mockContext.getDir(any(), any())).thenReturn(Files.createTempDirectory("events").toFile())
+        whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(mockSharedPrefs)
+        whenever(mockSharedPrefs.edit()).thenReturn(mockSharedPrefsEdit)
+        whenever(mockSharedPrefsEdit.putString(any(), any())).thenReturn(mockSharedPrefsEdit)
+        doNothing().whenever(mockSharedPrefsEdit).apply()
     }
 
     @Test

--- a/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
@@ -61,6 +61,7 @@ class ConfidenceIntegrationTests {
             )
         )
 
+        // we do create a confidence object to have the visitor id injected into the context
         val oldConfidence = ConfidenceFactory.create(mockContext, clientSecret)
         oldConfidence.putContext(evalMap.toConfidenceContext().map)
         val context = oldConfidence.getContext()

--- a/Provider/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.spotify.confidence
 
 import android.content.Context
+import android.content.SharedPreferences
 import com.spotify.confidence.client.SdkMetadata
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -10,6 +11,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.File
@@ -17,6 +20,8 @@ import java.nio.file.Files
 
 private const val clientSecret = "WciJVLIEiNnRxV8gaYPZNCFF8vbAXOu6"
 private val mockContext: Context = mock()
+private val mockSharedPrefs: SharedPreferences = mock()
+private val mockSharedPrefsEdit: SharedPreferences.Editor = mock()
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EventSenderIntegrationTest {
@@ -27,10 +32,27 @@ class EventSenderIntegrationTest {
     @Before
     fun setup() {
         whenever(mockContext.getDir("events", Context.MODE_PRIVATE)).thenReturn(directory)
+        whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(mockSharedPrefs)
+        whenever(mockSharedPrefs.edit()).thenReturn(mockSharedPrefsEdit)
+        whenever(mockSharedPrefsEdit.putString(any(), any())).thenReturn(mockSharedPrefsEdit)
+        doNothing().whenever(mockSharedPrefsEdit).apply()
         eventSender = null
         for (file in directory.walkFiles()) {
             file.delete()
         }
+    }
+
+    @Test
+    fun created_event_sender_has_visitor_id_context() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        eventSender = ConfidenceFactory.create(
+            mockContext,
+            clientSecret,
+            dispatcher = testDispatcher
+        )
+        val context = eventSender?.getContext()
+        Assert.assertNotNull(context)
+        Assert.assertTrue(context!!.containsKey(VISITOR_ID_CONTEXT_KEY))
     }
 
     @Test

--- a/Provider/src/test/java/com/spotify/confidence/InMemorySharedPreferences.kt
+++ b/Provider/src/test/java/com/spotify/confidence/InMemorySharedPreferences.kt
@@ -1,0 +1,97 @@
+package com.spotify.confidence
+
+import android.content.SharedPreferences
+
+internal class InMemorySharedPreferences : SharedPreferences {
+    private var visitorId: String = ""
+    override fun getAll(): MutableMap<String, *> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getString(key: String?, default: String?): String? =
+        if (key == VISITOR_ID_SHARED_PREFS_KEY) {
+            visitorId
+        } else {
+            default
+        }
+
+    override fun getStringSet(p0: String?, p1: MutableSet<String>?): MutableSet<String>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInt(p0: String?, p1: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLong(p0: String?, p1: Long): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFloat(p0: String?, p1: Float): Float {
+        TODO("Not yet implemented")
+    }
+
+    override fun getBoolean(p0: String?, p1: Boolean): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun contains(key: String?) = if (key == VISITOR_ID_SHARED_PREFS_KEY) {
+        visitorId.isNotEmpty()
+    } else {
+        false
+    }
+
+    override fun edit(): SharedPreferences.Editor = object : SharedPreferences.Editor {
+        private var visitorId: String = ""
+        override fun putString(key: String?, value: String?): SharedPreferences.Editor {
+            if (key == VISITOR_ID_SHARED_PREFS_KEY) {
+                visitorId = value ?: ""
+            }
+            return this
+        }
+
+        override fun putStringSet(p0: String?, p1: MutableSet<String>?): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putInt(p0: String?, p1: Int): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putLong(p0: String?, p1: Long): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putFloat(p0: String?, p1: Float): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putBoolean(p0: String?, p1: Boolean): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun remove(p0: String?): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun clear(): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun commit(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun apply() {
+            this@InMemorySharedPreferences.visitorId = this.visitorId
+        }
+    }
+
+    override fun registerOnSharedPreferenceChangeListener(p0: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(p0: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
While doing this I met with the issue of a stale context in a test.
Me and @vahidlazio decided that it made most sense with regards to our discussions this week to send back the actual value but also to signal in the `errorCode` that the evaluation may be stale.
The Open feature provider however "swallows" that error code.