### PR TITLE
refactor: Add `message` container to `payload`

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Provider/src/main/java/com/spotify/confidence/Confidence.kt
@@ -83,10 +83,10 @@ class Confidence internal constructor(
     }
 
     override fun send(
-        definition: String,
-        payload: ConfidenceFieldsType
+        eventName: String,
+        message: ConfidenceFieldsType
     ) {
-        eventSenderEngine.emit(definition, payload, getContext())
+        eventSenderEngine.emit(eventName, message, getContext())
     }
 }
 

--- a/Provider/src/main/java/com/spotify/confidence/EventSender.kt
+++ b/Provider/src/main/java/com/spotify/confidence/EventSender.kt
@@ -2,8 +2,8 @@ package com.spotify.confidence
 
 interface EventSender : Contextual {
     fun send(
-        definition: String,
-        payload: ConfidenceFieldsType = mapOf()
+        eventName: String,
+        message: ConfidenceFieldsType = mapOf()
     )
 
     override fun withContext(context: Map<String, ConfidenceValue>): EventSender

--- a/Provider/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Provider/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -17,7 +17,7 @@ import java.io.File
 
 internal interface EventSenderEngine {
     fun onLowMemoryChannel(): Channel<List<File>>
-    fun emit(definition: String, payload: ConfidenceFieldsType, context: Map<String, ConfidenceValue>)
+    fun emit(eventName: String, message: ConfidenceFieldsType, context: Map<String, ConfidenceValue>)
 
     fun stop()
 }
@@ -85,12 +85,12 @@ internal class EventSenderEngineImpl(
     override fun onLowMemoryChannel(): Channel<List<File>> {
         return eventStorage.onLowMemoryChannel()
     }
-    override fun emit(definition: String, payload: ConfidenceFieldsType, context: Map<String, ConfidenceValue>) {
+    override fun emit(eventName: String, message: ConfidenceFieldsType, context: Map<String, ConfidenceValue>) {
         coroutineScope.launch {
             val event = Event(
-                eventDefinition = "eventDefinitions/$definition",
+                eventDefinition = "eventDefinitions/$eventName",
                 eventTime = clock.currentTime(),
-                payload = payload + context
+                payload = message + context
             )
             writeReqChannel.send(event)
         }

--- a/Provider/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Provider/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -86,11 +86,13 @@ internal class EventSenderEngineImpl(
         return eventStorage.onLowMemoryChannel()
     }
     override fun emit(eventName: String, message: ConfidenceFieldsType, context: Map<String, ConfidenceValue>) {
+        val mutablePayload = context.toMutableMap()
+        mutablePayload["message"] = ConfidenceValue.Struct(message)
         coroutineScope.launch {
             val event = Event(
                 eventDefinition = "eventDefinitions/$eventName",
                 eventTime = clock.currentTime(),
-                payload = message + context
+                payload = mutablePayload
             )
             writeReqChannel.send(event)
         }

--- a/Provider/src/main/java/com/spotify/confidence/EventSenderUploader.kt
+++ b/Provider/src/main/java/com/spotify/confidence/EventSenderUploader.kt
@@ -52,6 +52,7 @@ internal class EventSenderUploaderImpl(
     }
 
     override suspend fun upload(events: EventBatchRequest): Boolean = withContext(dispatcher) {
+        Event
         val networkJson = Json {
             serializersModule = SerializersModule {
                 contextual(NetworkConfidenceValueSerializer)

--- a/Provider/src/main/java/com/spotify/confidence/EventSenderUploader.kt
+++ b/Provider/src/main/java/com/spotify/confidence/EventSenderUploader.kt
@@ -52,7 +52,6 @@ internal class EventSenderUploaderImpl(
     }
 
     override suspend fun upload(events: EventBatchRequest): Boolean = withContext(dispatcher) {
-        Event
         val networkJson = Json {
             serializersModule = SerializersModule {
                 contextual(NetworkConfidenceValueSerializer)

--- a/Provider/src/main/java/com/spotify/confidence/EventSenderUploader.kt
+++ b/Provider/src/main/java/com/spotify/confidence/EventSenderUploader.kt
@@ -57,6 +57,7 @@ internal class EventSenderUploaderImpl(
                 contextual(NetworkConfidenceValueSerializer)
             }
         }
+
         val httpRequest = Request.Builder()
             .url(BASE_URL)
             .headers(headers)

--- a/Provider/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -125,6 +125,68 @@ class EventSenderIntegrationTest {
     }
 
     @Test
+    fun payload_on_emit() = runTest {
+        val eventStorage = EventStorageImpl(mockContext)
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val batchSize = 1
+        val uploadedEvents: MutableList<Event> = mutableListOf()
+        val flushPolicy = object : FlushPolicy {
+            private var size = 0
+            override fun reset() {
+                size = 0
+            }
+
+            override fun hit(event: Event) {
+                size++
+            }
+
+            override fun shouldFlush(): Boolean {
+                return size >= batchSize
+            }
+        }
+        val uploader = object : EventSenderUploader {
+            override suspend fun upload(events: EventBatchRequest): Boolean {
+                uploadedEvents.addAll(events.events)
+                return false
+            }
+        }
+        val engine = EventSenderEngineImpl(
+            eventStorage,
+            clientSecret,
+            flushPolicies = listOf(flushPolicy),
+            dispatcher = testDispatcher,
+            sdkMetadata = SdkMetadata("kotlin_test", ""),
+            uploader = uploader
+        )
+        engine.emit(
+            eventName = "my_event",
+            message = mapOf(
+                "a" to ConfidenceValue.Integer(0),
+                "message" to ConfidenceValue.Integer(1)
+            ),
+            context = mapOf(
+                "a" to ConfidenceValue.Integer(2),
+                "message" to ConfidenceValue.Integer(3)
+            )
+        )
+        advanceUntilIdle()
+        Assert.assertEquals("eventDefinitions/my_event", uploadedEvents[0].eventDefinition)
+        Assert.assertEquals(
+            mapOf(
+                "message" to ConfidenceValue.Struct(
+                    mapOf(
+                        "a" to ConfidenceValue.Integer(0),
+                        "message" to ConfidenceValue.Integer(1)
+                    )
+                ),
+                "a" to ConfidenceValue.Integer(2)
+            ),
+            uploadedEvents[0].payload
+        )
+        print(uploadedEvents)
+    }
+
+    @Test
     fun emitting_an_event_batches_all_batches_sent_cleaned_up() = runTest {
         val eventStorage = EventStorageImpl(mockContext)
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)

--- a/Provider/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -125,7 +125,7 @@ class EventSenderIntegrationTest {
     }
 
     @Test
-    fun payload_on_emit() = runTest {
+    fun handles_message_key_collision() = runTest {
         val eventStorage = EventStorageImpl(mockContext)
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
         val batchSize = 1


### PR DESCRIPTION
Also minor changes in the various interfaces and how events are stored on disk